### PR TITLE
Add missing CFLAGS for optimization and debug info

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 AUTOMAKE_OPTIONS = subdir-objects
 
 ACLOCAL_AMFLAGS =  -I m4
-AM_CFLAGS = -std=gnu11 -flto -fuse-linker-plugin -I$(srcdir)/src
+AM_CFLAGS = -std=gnu11 -g -O3 -flto -fuse-linker-plugin -I$(srcdir)/src
 
 SOURCE_FILES = \
 src/picohttpparser/picohttpparser.c \


### PR DESCRIPTION
I noticed these were missing, I assume it was an oversight. It took me a while to figure out why the new libreactor was so much slower than the [old one](https://github.com/fredrikwidlund/libreactor_old).