### PR TITLE
Add BPF support to the release-2.0 branch

### DIFF
--- a/src/reactor/server.c
+++ b/src/reactor/server.c
@@ -139,8 +139,19 @@ static int server_fd_bind(server *server, uint32_t ip, uint16_t port)
 void server_construct(server *server, core_callback *callback, void *state)
 {
   *server = (struct server) {.user = {.callback = callback, .state = state}, .fd = -1};
+  server->options = SERVER_OPTION_DEFAULTS;
   timer_construct(&server->timer, server_timer_handler, server);
   list_construct(&server->sessions);
+}
+
+void server_option_set(server *server, server_options options)
+{
+  server->options |= options;
+}
+
+void server_option_clear(server *server, server_options options)
+{
+  server->options &= ~options;
 }
 
 void server_open(server *server, uint32_t ip, uint16_t port)

--- a/src/reactor/server.h
+++ b/src/reactor/server.h
@@ -1,6 +1,14 @@
 #ifndef SERVER_H_INCLUDED
 #define SERVER_H_INCLUDED
 
+#define SERVER_OPTION_DEFAULTS 0x00
+
+enum server_options
+{
+  SERVER_OPTION_BPF       = 0x01
+};
+typedef enum server_options server_options;
+
 enum
 {
   SERVER_ERROR,
@@ -18,6 +26,7 @@ struct server
   int             fd;
   int             next;
   list            sessions;
+  server_options  options;
 };
 
 struct server_context
@@ -33,6 +42,8 @@ struct server_session
 };
 
 void server_construct(server *, core_callback *, void *);
+void server_option_set(server *, server_options);
+void server_option_clear(server *, server_options);
 void server_open(server *, uint32_t, uint16_t);
 void server_close(server *);
 void server_destruct(server *);


### PR DESCRIPTION
As described in issue #9, this PR adds optional support for using the SO_ATTACH_REUSEPORT_CBPF socket option. I mimicked the code from reactor_net.c/h for setting options.